### PR TITLE
Update output file name in AIS postprocess script

### DIFF
--- a/src/emulandice/emulandice_AIS_postprocess.py
+++ b/src/emulandice/emulandice_AIS_postprocess.py
@@ -145,7 +145,7 @@ def emulandice_postprocess_AIS(
             attrs=ncvar_attributes,
         )
         eais_out.to_netcdf(
-            "{0}_{1}_localsl.nc".format(pipeline_id, "EAIS"),
+            output_eais_file,
             encoding={
                 "sea_level_change": {
                     "dtype": "f4",


### PR DESCRIPTION
This PR changes the filename that is passed to `ds.to_netcdf()` in the emulandice AIS postprocess script, it looks like maybe the filename from the old approach was still in instead of using the output filename passed from the CLI 